### PR TITLE
Add ability to path license as data and not file path

### DIFF
--- a/examples/standalone-mounted/main.tf
+++ b/examples/standalone-mounted/main.tf
@@ -35,7 +35,7 @@ module "secrets" {
   source = "../../fixtures/secrets"
   tfe_license = {
     name = "${local.friendly_name_prefix}-license"
-    path = var.license_file
+    data = var.license_content
   }
 }
 

--- a/examples/standalone-mounted/variables.tf
+++ b/examples/standalone-mounted/variables.tf
@@ -16,6 +16,11 @@ variable "license_file" {
   description = "The local path to the Terraform Enterprise license."
 }
 
+variable "license_content" {
+  type        = string
+  description = "The Terraform Enterprise license."
+}
+
 variable "tags" {
   type        = map(string)
   description = <<DESC

--- a/fixtures/secrets/main.tf
+++ b/fixtures/secrets/main.tf
@@ -8,8 +8,14 @@ resource "aws_secretsmanager_secret" "tfe_license" {
 }
 
 resource "aws_secretsmanager_secret_version" "tfe_license" {
-  count         = var.tfe_license == null ? 0 : 1
+  count         = var.tfe_license.path == null ? 0 : 1
   secret_binary = filebase64(var.tfe_license.path)
+  secret_id     = aws_secretsmanager_secret.tfe_license[count.index].id
+}
+
+resource "aws_secretsmanager_secret_version" "tfe_license_data" {
+  count         = var.tfe_license.data == null ? 0 : 1
+  secret_binary = base64encode(var.tfe_license.data)
   secret_id     = aws_secretsmanager_secret.tfe_license[count.index].id
 }
 


### PR DESCRIPTION
## Background

To store the licence, a variable is set with the licence file path. 
Need to have the ability to pass the licence directly as a variable



## How Has This Been Tested

Not fully tested at this time

